### PR TITLE
Allow Quarry to be forward-compatible with future Anchor versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,7 +950,6 @@ dependencies = [
  "num-traits",
  "quarry-mine",
  "quarry-mint-wrapper",
- "solana-program",
  "spl-associated-token-account",
  "vipers",
 ]
@@ -965,7 +964,6 @@ dependencies = [
  "proptest",
  "quarry-mint-wrapper",
  "rand 0.8.4",
- "solana-program",
  "spl-associated-token-account",
  "spl-math",
  "vipers",
@@ -977,7 +975,6 @@ version = "1.9.0"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
- "solana-program",
  "vipers",
 ]
 
@@ -997,7 +994,6 @@ version = "1.9.0"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
- "solana-program",
  "spl-associated-token-account",
  "vipers",
 ]
@@ -1008,7 +1004,6 @@ version = "1.9.0"
 dependencies = [
  "anchor-lang",
  "quarry-mine",
- "solana-program",
  "vipers",
 ]
 
@@ -1583,13 +1578,12 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "vipers"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8960b053a136ee9be9620d0e57c386803db236fa041255b3c6bf135bd7fae4d7"
+checksum = "bea75cc284e29a67b15c7f509d4eb535f87182233700e25489e4db04bf9c1dbf"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
- "solana-program",
  "spl-associated-token-account",
 ]
 

--- a/programs/quarry-merge-mine/Cargo.toml
+++ b/programs/quarry-merge-mine/Cargo.toml
@@ -20,13 +20,12 @@ cpi = ["no-entrypoint"]
 default = []
 
 [dependencies]
-anchor-lang = "0.17.0"
-anchor-spl = "0.17.0"
+anchor-lang = ">=0.17.0"
+anchor-spl = ">=0.17.0"
 quarry-mine = { path = "../quarry-mine", features = ["cpi"], version = "1.8.0" }
 quarry-mint-wrapper = { path = "../quarry-mint-wrapper", features = [
     "cpi"
 ], version = "1.3.0" }
 num-traits = "0.2"
-vipers = "1.2.1"
-solana-program = "1.7.11"
+vipers = "1.3.0"
 spl-associated-token-account = "1.0.3"

--- a/programs/quarry-mine/Cargo.toml
+++ b/programs/quarry-mine/Cargo.toml
@@ -20,18 +20,17 @@ cpi = ["no-entrypoint"]
 default = []
 
 [dependencies]
-anchor-lang = "0.17.0"
-anchor-spl = "0.17.0"
+anchor-lang = ">=0.17.0"
+anchor-spl = ">=0.17.0"
 num-traits = "0.2.14"
 quarry-mint-wrapper = { path = "../quarry-mint-wrapper", features = [
   "cpi"
 ], version = "1.7.0" }
-solana-program = "1.7.11"
 spl-associated-token-account = { version = "1.0.3", features = [
   "no-entrypoint"
 ] }
 spl-math = { version = "0.1.0", features = ["no-entrypoint"] }
-vipers = "1.2.1"
+vipers = "1.3.0"
 
 [dev-dependencies]
 proptest = { version = "1.0" }

--- a/programs/quarry-mine/src/addresses.rs
+++ b/programs/quarry-mine/src/addresses.rs
@@ -5,12 +5,16 @@ use anchor_lang::prelude::*;
 
 /// Wrapper module.
 pub mod fee_to {
-    solana_program::declare_id!("4MMZH3ih1aSty2nx4MC3kSR94Zb55XsXnqb5jfEcyHWQ");
+    use anchor_lang::declare_id;
+
+    declare_id!("4MMZH3ih1aSty2nx4MC3kSR94Zb55XsXnqb5jfEcyHWQ");
 }
 
 /// Wrapper module.
 pub mod fee_setter {
-    solana_program::declare_id!("4MMZH3ih1aSty2nx4MC3kSR94Zb55XsXnqb5jfEcyHWQ");
+    use anchor_lang::declare_id;
+
+    declare_id!("4MMZH3ih1aSty2nx4MC3kSR94Zb55XsXnqb5jfEcyHWQ");
 }
 
 /// Account authorized to take fees.

--- a/programs/quarry-mine/src/lib.rs
+++ b/programs/quarry-mine/src/lib.rs
@@ -14,7 +14,6 @@
 mod macros;
 
 use anchor_lang::prelude::*;
-use anchor_lang::Key;
 use anchor_spl::token::Token;
 use anchor_spl::token::{self, Mint, TokenAccount, Transfer};
 use payroll::Payroll;
@@ -31,7 +30,7 @@ pub mod rewarder;
 
 use crate::quarry::StakeAction;
 
-solana_program::declare_id!("QMNeHCGYnLVDn1icRAfQZpjPLBNkfGbSKRB83G5d8KB");
+declare_id!("QMNeHCGYnLVDn1icRAfQZpjPLBNkfGbSKRB83G5d8KB");
 
 /// Maximum number of tokens that can be rewarded by a [Rewarder] per year.
 pub const MAX_ANNUAL_REWARDS_RATE: u64 = u64::MAX >> 3;

--- a/programs/quarry-mint-wrapper/Cargo.toml
+++ b/programs/quarry-mint-wrapper/Cargo.toml
@@ -20,7 +20,6 @@ cpi = ["no-entrypoint"]
 default = []
 
 [dependencies]
-anchor-lang = "0.17.0"
-anchor-spl = "0.17.0"
-vipers = "1.2.1"
-solana-program = "1.7.11"
+anchor-lang = ">=0.17.0"
+anchor-spl = ">=0.17.0"
+vipers = "1.3.0"

--- a/programs/quarry-mint-wrapper/src/lib.rs
+++ b/programs/quarry-mint-wrapper/src/lib.rs
@@ -6,7 +6,6 @@
 mod macros;
 
 use anchor_lang::prelude::*;
-use anchor_lang::Key;
 use anchor_spl::token::Token;
 use anchor_spl::token::{self, Mint, TokenAccount};
 use vipers::unwrap_int;
@@ -14,7 +13,7 @@ use vipers::validate::Validate;
 
 mod account_validators;
 
-solana_program::declare_id!("QMWoBmAyJLAsA1Lh9ugMTw2gciTihncciphzdNzdZYV");
+declare_id!("QMWoBmAyJLAsA1Lh9ugMTw2gciTihncciphzdNzdZYV");
 
 #[program]
 pub mod quarry_mint_wrapper {

--- a/programs/quarry-operator/Cargo.toml
+++ b/programs/quarry-operator/Cargo.toml
@@ -20,7 +20,7 @@ cpi = ["no-entrypoint"]
 default = []
 
 [dependencies]
-anchor-lang = "0.17.0"
-anchor-spl = "0.17.0"
+anchor-lang = ">=0.17.0"
+anchor-spl = ">=0.17.0"
 quarry-mine = { path = "../quarry-mine", version = "1.9.0", features = ["cpi"] }
-vipers = "1.2.1"
+vipers = "1.3.0"

--- a/programs/quarry-redeemer/Cargo.toml
+++ b/programs/quarry-redeemer/Cargo.toml
@@ -20,10 +20,9 @@ cpi = ["no-entrypoint"]
 default = []
 
 [dependencies]
-anchor-lang = "0.17.0"
-anchor-spl = "0.17.0"
-solana-program = "1.7.11"
+anchor-lang = ">=0.17.0"
+anchor-spl = ">=0.17.0"
 spl-associated-token-account = { version = "1.0.3", features = [
   "no-entrypoint"
 ] }
-vipers = "1.2.1"
+vipers = "1.3.0"

--- a/programs/quarry-redeemer/src/lib.rs
+++ b/programs/quarry-redeemer/src/lib.rs
@@ -3,10 +3,8 @@
 #![allow(rustdoc::missing_doc_code_examples)]
 
 use anchor_lang::prelude::*;
-use anchor_lang::Key;
 use anchor_spl::token::Token;
 use anchor_spl::token::{Mint, TokenAccount};
-use solana_program::declare_id;
 use vipers::invariant;
 use vipers::unwrap_int;
 use vipers::validate::Validate;

--- a/programs/quarry-registry/Cargo.toml
+++ b/programs/quarry-registry/Cargo.toml
@@ -20,7 +20,6 @@ cpi = ["no-entrypoint"]
 default = []
 
 [dependencies]
-anchor-lang = "0.17.0"
+anchor-lang = ">=0.17.0"
 quarry-mine = { version = "1.7.0", path = "../quarry-mine", features = ["cpi"] }
-solana-program = "1.7.11"
-vipers = "1.2.1"
+vipers = "1.3.0"

--- a/programs/quarry-registry/src/lib.rs
+++ b/programs/quarry-registry/src/lib.rs
@@ -3,13 +3,12 @@
 #![allow(rustdoc::missing_doc_code_examples)]
 
 use anchor_lang::prelude::*;
-use anchor_lang::Key;
 use quarry_mine::Quarry;
 use quarry_mine::Rewarder;
 
 mod account_validators;
 
-solana_program::declare_id!("QREGBnEj9Sa5uR91AV8u3FxThgP5ZCvdZUW2bHAkfNc");
+declare_id!("QREGBnEj9Sa5uR91AV8u3FxThgP5ZCvdZUW2bHAkfNc");
 
 #[program]
 pub mod quarry_registry {


### PR DESCRIPTION
Changes the version of Anchor to allow forward-compatibility.

We are building on Anchor 0.18.0 and we can't compile because of a hard dependency on Solana v1.7.