### PR TITLE
improve clarity of kbps -> millibips

### DIFF
--- a/programs/quarry-mine/src/lib.rs
+++ b/programs/quarry-mine/src/lib.rs
@@ -35,9 +35,9 @@ declare_id!("QMNeHCGYnLVDn1icRAfQZpjPLBNkfGbSKRB83G5d8KB");
 /// Maximum number of tokens that can be rewarded by a [Rewarder] per year.
 pub const MAX_ANNUAL_REWARDS_RATE: u64 = u64::MAX >> 3;
 
-/// The fees of new [Rewarder]s-- 1,000 KBPS = 1 BP or 0.01%.
+/// The fees of new [Rewarder]s: 1,000 milliBPS = 1 BP or 0.01%.
 /// This may be changed by governance in the future via program upgrade.
-pub const DEFAULT_CLAIM_FEE_KBPS: u64 = 1_000;
+pub const DEFAULT_CLAIM_FEE_MILLIBPS: u64 = 1_000;
 
 /// Program for [quarry_mine].
 #[program]
@@ -67,7 +67,7 @@ pub mod quarry_mine {
         rewarder.rewards_token_mint = ctx.accounts.rewards_token_mint.key();
 
         rewarder.claim_fee_token_account = ctx.accounts.claim_fee_token_account.key();
-        rewarder.max_claim_fee_kbps = DEFAULT_CLAIM_FEE_KBPS;
+        rewarder.max_claim_fee_millibps = DEFAULT_CLAIM_FEE_MILLIBPS;
 
         rewarder.pause_authority = Pubkey::default();
         rewarder.is_paused = false;
@@ -435,10 +435,10 @@ pub struct Rewarder {
     /// Claim fees are placed in this account.
     pub claim_fee_token_account: Pubkey,
     /// Maximum amount of tokens to send to the Quarry DAO on each claim,
-    /// in terms of thousands of BPS.
+    /// in terms of milliBPS. 1,000 milliBPS = 1 BPS = 0.01%
     /// This is stored on the [Rewarder] to ensure that the fee will
     /// not exceed this in the future.
-    pub max_claim_fee_kbps: u64,
+    pub max_claim_fee_millibps: u64,
 
     /// Authority allowed to pause a [Rewarder].
     pub pause_authority: Pubkey,

--- a/programs/quarry-mine/src/rewarder.rs
+++ b/programs/quarry-mine/src/rewarder.rs
@@ -59,10 +59,10 @@ impl<'info> ClaimRewards<'info> {
         }
 
         // Calculate rewards
-        let max_claim_fee_kbps = self.stake.rewarder.max_claim_fee_kbps;
-        require!(max_claim_fee_kbps < 10_000 * 1_000, InvalidMaxClaimFee);
+        let max_claim_fee_millibps = self.stake.rewarder.max_claim_fee_millibps;
+        require!(max_claim_fee_millibps < 10_000 * 1_000, InvalidMaxClaimFee);
         let max_claim_fee = unwrap_int!((amount_claimable as u128)
-            .checked_mul(max_claim_fee_kbps.into())
+            .checked_mul(max_claim_fee_millibps.into())
             .and_then(|f| f.checked_div((10_000 * 1_000) as u128))
             .and_then(|f| f.to_u64()));
 


### PR DESCRIPTION
```
milli = 0.001
kilo = 1000
1000 KBPS     = 1 kilo BPS  = 1000  * 1000 BPS = 1000000 BPS = 10,000%
1000 milliBPS = 1 milli BPS = 0.001 * 1000 BPS = 0.01    BPS = 0.01%
```

I chose `milli` instead of `M` because some people could interpret M as `roman numeral 1000` or `million`.

This fixes the incorrect labeling. It is just a labeling change. The struct for the `quarry_mine::Rewarder` is unchanged.