### PR TITLE
Remove mut constraints from the unused accounts

### DIFF
--- a/programs/quarry-mine/src/lib.rs
+++ b/programs/quarry-mine/src/lib.rs
@@ -783,11 +783,9 @@ pub struct UserClaim<'info> {
     pub quarry: Account<'info, Quarry>,
 
     /// Placeholder for the miner vault.
-    #[account(mut)]
     pub unused_miner_vault: UncheckedAccount<'info>,
 
     /// Placeholder for the user's staked token account.
-    #[account(mut)]
     pub unused_token_account: UncheckedAccount<'info>,
 
     /// Token program


### PR DESCRIPTION
Once this is merged, this needs to be deployed ASAP otherwise it will break the library for consumers.