### PR TITLE
Fix set_rewards_share

### DIFF
--- a/programs/quarry-mine/src/lib.rs
+++ b/programs/quarry-mine/src/lib.rs
@@ -20,7 +20,6 @@ use anchor_spl::token::Token;
 use anchor_spl::token::{self, Mint, TokenAccount, Transfer};
 use payroll::Payroll;
 pub use state::*;
-use std::cmp;
 use vipers::prelude::*;
 
 pub mod account_validators;

--- a/programs/quarry-mine/src/lib.rs
+++ b/programs/quarry-mine/src/lib.rs
@@ -178,17 +178,16 @@ pub mod quarry_mine {
             .checked_add(new_share)
             .and_then(|v| v.checked_sub(quarry.rewards_share)));
 
-        let now = Clock::get()?.unix_timestamp;
-        quarry.last_update_ts = cmp::min(now, quarry.famine_ts);
-        quarry.annual_rewards_rate = rewarder.compute_quarry_annual_rewards_rate(new_share)?;
         quarry.rewards_share = new_share;
-
-        emit!(QuarryRewardsUpdateEvent {
-            token_mint: quarry.token_mint_key,
-            annual_rewards_rate: quarry.annual_rewards_rate,
-            rewards_share: quarry.rewards_share,
-            timestamp: now,
-        });
+        // Do not update annual_rewards_rate here. Just wait for the update_quarry_rewards call
+        // because rewarder.total_rewards_shares may change with other quarry share changes
+        // and quarry.annual_rewards_rate calculated here will become invalid.
+        // The correct share update procedure is calling all set_rewards_share
+        // first (with set_annual_rewards if needed) and update_quarry_rewards
+        // for each quarry to finalize changes.
+        // TODO: because update_quarry_rewards is permissionless better
+        // to add protection from calling it after admin started to change the rates
+        // and commit_changes instruction making possible to call update_quarry_rewards again
 
         Ok(())
     }
@@ -602,7 +601,7 @@ pub struct RewarderAnnualRewardsUpdateEvent {
     pub timestamp: i64,
 }
 
-/// Emitted when a quarry's reward share is updated.
+/// Emitted when a quarry's reward rate is updated.
 #[event]
 pub struct QuarryRewardsUpdateEvent {
     /// [Mint] of the [Quarry] token.

--- a/tests/mine.spec.ts
+++ b/tests/mine.spec.ts
@@ -541,10 +541,36 @@ describe("Mine", () => {
           quarryRewardsShare.toString()
         );
 
-        const quarry = await rewarder.getQuarry(stakeToken);
+        let quarry = await rewarder.getQuarry(stakeToken);
         expect(quarry.key).to.eqAddress(quarryKey);
+        expect(quarry.quarryData.lastUpdateTs.toString()).to.equal(
+          quarryData.lastUpdateTs.toString()
+        );
+        expect(quarry.quarryData.annualRewardsRate.toString()).to.equal(
+          quarryData.annualRewardsRate.toString()
+        );
         expect(quarry.quarryData.rewardsShare.toString()).to.eq(
           quarryRewardsShare.toString()
+        );
+        expect(quarry.quarryData.annualRewardsRate.toString()).to.not.equal(
+          quarry.computeAnnualRewardsRate().toString()
+        );
+
+        const currentTime = Math.floor(new Date().getTime() / 1000);
+        await assert.doesNotReject(async () => {
+          const tx = await rewarder.syncQuarryRewards([stakeTokenMint]);
+          await tx.confirm();
+        });
+        quarry = await rewarder.getQuarry(stakeToken);
+        expect(
+          quarry.quarryData.lastUpdateTs
+            .sub(new BN(currentTime))
+            .abs()
+            .lte(new BN(1))
+        ).to.be.true;
+        const expectedRewardsRate = quarry.computeAnnualRewardsRate();
+        expect(quarry.quarryData.annualRewardsRate.toString()).to.equal(
+          expectedRewardsRate.toString()
         );
       });
 
@@ -891,10 +917,36 @@ describe("Mine", () => {
           quarryRewardsShare.toString()
         );
 
-        const quarry = await rewarder.getQuarry(stakeToken);
+        let quarry = await rewarder.getQuarry(stakeToken);
         expect(quarry.key).to.eqAddress(quarryKey);
+        expect(quarry.quarryData.lastUpdateTs.toString()).to.equal(
+          quarryData.lastUpdateTs.toString()
+        );
+        expect(quarry.quarryData.annualRewardsRate.toString()).to.equal(
+          quarryData.annualRewardsRate.toString()
+        );
         expect(quarry.quarryData.rewardsShare.toString()).to.eq(
           quarryRewardsShare.toString()
+        );
+        expect(quarry.quarryData.annualRewardsRate.toString()).to.not.equal(
+          quarry.computeAnnualRewardsRate().toString()
+        );
+
+        const currentTime = Math.floor(new Date().getTime() / 1000);
+        await assert.doesNotReject(async () => {
+          const tx = await rewarder.syncQuarryRewards([stakeTokenMint]);
+          await tx.confirm();
+        });
+        quarry = await rewarder.getQuarry(stakeToken);
+        expect(
+          quarry.quarryData.lastUpdateTs
+            .sub(new BN(currentTime))
+            .abs()
+            .lte(new BN(1))
+        ).to.be.true;
+        const expectedRewardsRate = quarry.computeAnnualRewardsRate();
+        expect(quarry.quarryData.annualRewardsRate.toString()).to.equal(
+          expectedRewardsRate.toString()
         );
       });
 

--- a/tests/mine.spec.ts
+++ b/tests/mine.spec.ts
@@ -522,8 +522,6 @@ describe("Mine", () => {
       });
 
       it("Set rewards share", async () => {
-        const currentTime = Math.floor(new Date().getTime() / 1000);
-
         await assert.doesNotReject(async () => {
           await mine.program.rpc.setRewardsShare(quarryRewardsShare, {
             accounts: {
@@ -874,8 +872,6 @@ describe("Mine", () => {
       });
 
       it("Set rewards share", async () => {
-        const currentTime = Math.floor(new Date().getTime() / 1000);
-
         await assert.doesNotReject(async () => {
           await mine.program.rpc.setRewardsShare(quarryRewardsShare, {
             accounts: {
@@ -897,16 +893,6 @@ describe("Mine", () => {
 
         const quarry = await rewarder.getQuarry(stakeToken);
         expect(quarry.key).to.eqAddress(quarryKey);
-        expect(
-          quarry.quarryData.lastUpdateTs
-            .sub(new BN(currentTime))
-            .abs()
-            .lte(new BN(1))
-        ).to.be.true;
-        const expectedRewardsRate = quarry.computeAnnualRewardsRate();
-        expect(quarry.quarryData.annualRewardsRate.toString()).to.equal(
-          expectedRewardsRate.toString()
-        );
         expect(quarry.quarryData.rewardsShare.toString()).to.eq(
           quarryRewardsShare.toString()
         );

--- a/tests/mine.spec.ts
+++ b/tests/mine.spec.ts
@@ -545,16 +545,6 @@ describe("Mine", () => {
 
         const quarry = await rewarder.getQuarry(stakeToken);
         expect(quarry.key).to.eqAddress(quarryKey);
-        expect(
-          quarry.quarryData.lastUpdateTs
-            .sub(new BN(currentTime))
-            .abs()
-            .lte(new BN(1))
-        ).to.be.true;
-        const expectedRewardsRate = quarry.computeAnnualRewardsRate();
-        expect(quarry.quarryData.annualRewardsRate.toString()).to.equal(
-          expectedRewardsRate.toString()
-        );
         expect(quarry.quarryData.rewardsShare.toString()).to.eq(
           quarryRewardsShare.toString()
         );


### PR DESCRIPTION
set_rewards_share was updating last_update_ts but not updating rewards_per_token_stored. This was making rewards rate 0 for quarry from the last update until the set_rewards_share call and was the source of losing rewards, especially for corner cases like single user quarry.
Admins of existent quarries must check their changing quarry share procedure to be sure update_quarry_rewards/syncQuarries is called for each quarry after all shares changed otherwise setting shares will not take effect on rewards distribution